### PR TITLE
Add two dependent package: libssl-dev and libffi-dev

### DIFF
--- a/nodepool/scripts/install_devstack_dependencies.sh
+++ b/nodepool/scripts/install_devstack_dependencies.sh
@@ -42,7 +42,7 @@ elif [ -f /usr/bin/apt-get ]; then
     else
         sudo DEBIAN_FRONTEND=noninteractive apt-get \
             --option "Dpkg::Options::=--force-confold" \
-            --assume-yes install build-essential python-dev \
+            --assume-yes install build-essential python-dev libssl-dev libffi-dev \
             python-software-properties linux-headers-virtual linux-headers-`uname -r`
     fi
 else


### PR DESCRIPTION
check-citrix-xenserver CI failed due to lack of two packages, please check the detail logs: 
http://dd6b71949550285df7dc-dda4e480e005aaa13ec303551d2d8155.r49.cf1.rackcdn.com/53/311753/1/13516/run_tests.log

2016-05-02 14:27:07.933 | /tmp/ansible/local/lib/python2.7/site-packages/pip/_vendor/requests/packages/urllib3/util/ssl_.py:90: InsecurePlatformWarning: A true SSLContext object is not available. This prevents urllib3 from configuring SSL appropriately and may cause certain SSL connections to fail. For more information, see https://urllib3.readthedocs.org/en/latest/security.html#insecureplatformwarning.
2016-05-02 14:27:07.939 |   InsecurePlatformWarning
2016-05-02 14:27:07.946 |   Downloading ansible-2.0.0.2.tar.gz (1.5MB)
2016-05-02 14:27:07.953 | Collecting paramiko (from ansible==2.0.0.2)
2016-05-02 14:27:07.961 |   Downloading paramiko-2.0.0-py2.py3-none-any.whl (170kB)
2016-05-02 14:27:07.968 | Collecting jinja2 (from ansible==2.0.0.2)
2016-05-02 14:27:07.974 |   Downloading Jinja2-2.8-py2.py3-none-any.whl (263kB)
2016-05-02 14:27:07.980 | Collecting PyYAML (from ansible==2.0.0.2)
2016-05-02 14:27:07.987 | Requirement already satisfied (use --upgrade to upgrade): setuptools in /tmp/ansible/lib/python2.7/site-packages (from ansible==2.0.0.2)
2016-05-02 14:27:07.993 | Collecting pycrypto>=2.6 (from ansible==2.0.0.2)
2016-05-02 14:27:07.999 | Collecting pyasn1>=0.1.7 (from paramiko->ansible==2.0.0.2)
2016-05-02 14:27:08.004 |   Downloading pyasn1-0.1.9-py2.py3-none-any.whl
2016-05-02 14:27:08.011 | Collecting cryptography>=1.1 (from paramiko->ansible==2.0.0.2)
2016-05-02 14:27:08.017 |   Downloading cryptography-1.3.1.tar.gz (383kB)
2016-05-02 14:27:08.023 | Collecting MarkupSafe (from jinja2->ansible==2.0.0.2)
2016-05-02 14:27:08.029 | Collecting idna>=2.0 (from cryptography>=1.1->paramiko->ansible==2.0.0.2)
2016-05-02 14:27:08.035 |   Downloading idna-2.1-py2.py3-none-any.whl (54kB)
2016-05-02 14:27:08.041 | Collecting six>=1.4.1 (from cryptography>=1.1->paramiko->ansible==2.0.0.2)
2016-05-02 14:27:08.046 |   Using cached six-1.10.0-py2.py3-none-any.whl
2016-05-02 14:27:08.052 | Collecting enum34 (from cryptography>=1.1->paramiko->ansible==2.0.0.2)
2016-05-02 14:27:08.058 |   Using cached enum34-1.1.4-py2.py3-none-any.whl
2016-05-02 14:27:08.065 | Collecting ipaddress (from cryptography>=1.1->paramiko->ansible==2.0.0.2)
2016-05-02 14:27:08.072 |   Downloading ipaddress-1.0.16-py27-none-any.whl
2016-05-02 14:27:08.078 | Collecting cffi>=1.4.1 (from cryptography>=1.1->paramiko->ansible==2.0.0.2)
2016-05-02 14:27:08.085 |   Downloading cffi-1.6.0.tar.gz (397kB)
2016-05-02 14:27:08.093 | Collecting pycparser (from cffi>=1.4.1->cryptography>=1.1->paramiko->ansible==2.0.0.2)
2016-05-02 14:27:08.100 |   Downloading pycparser-2.14.tar.gz (223kB)
2016-05-02 14:27:08.107 | Building wheels for collected packages: ansible, cryptography, cffi, pycparser
2016-05-02 14:27:08.114 |   Running setup.py bdist_wheel for ansible
2016-05-02 14:27:08.121 |   Stored in directory: /root/.cache/pip/wheels/33/8f/c7/1e12dbc456ad2506c2c0614a628e7144ff883497d421138b27
2016-05-02 14:27:08.128 |   Running setup.py bdist_wheel for cryptography
2016-05-02 14:27:08.135 |   Complete output from command /tmp/ansible/bin/python -c "import setuptools;**file**='/tmp/pip-build-V_FmMB/cryptography/setup.py';exec(compile(open(**file**).read().replace('\r\n', '\n'), **file**, 'exec'))" bdist_wheel -d /tmp/tmpwlKLNvpip-wheel-:
2016-05-02 14:27:08.142 |   c/_cffi_backend.c:15:17: fatal error: ffi.h: No such file or directory
2016-05-02 14:27:08.149 |    #include <ffi.h>
2016-05-02 14:27:08.157 |                    ^
